### PR TITLE
Fix Neodash 2 build commands on macOS

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "scripts": {
     "dev": "npx webpack-dev-server --mode development",
-    "build": "npx webpack --mode production && rm -rf build && mkdir build && cp public/* build/ -r && mkdir build/dist &&  mv dist/ build/",
+    "build": "npx webpack --mode production && rm -rf build && mkdir build && cp -r public/* build/ && mkdir build/dist &&  mv dist/ build/",
     "sync": "aws s3 sync --acl public-read build s3://neodash.graphapp.io/preview",
     "test": "ts-mocha \"src/**/*.test.tsx\" --require @babel/register --recursive"
   },


### PR DESCRIPTION
First of all, thank you for developing Neodash! I think it will prove to be very useful for us (I work with @bartbroere).

This PR fixes the `build` commands on MacOS. The `cp` command on macOS (at least in Monterey using the default zsh shell) requires the `-r` flag to be supplied _before_ the source and target, not after.