### PR TITLE
Fix path to bundle.js

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,7 @@
 <body>
     <div id="root"></div>
     <noscript>Please enable JavaScript to view this site.</noscript>
-    <script src="../dist/bundle.js"></script>
+    <script src="dist/bundle.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
The path to the compiled Javascript file was wrong: it tries to go up a directory when it shouldn't. Amazingly the current version still works if you host directly from the `dist` folder I guess because there is no dir to go up to?

Anyway, this should make it work in all cases.