### PR TITLE
Pass Parameter Select value via hash to iframe without re-rendering

### DIFF
--- a/public/embed-test.html
+++ b/public/embed-test.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8" />
+    <title>Embed test</title>
+</head>
+
+<body>
+    <p>The page won't reload when passing global parameters via the url hash. You can verify this by playing the embedded YouTube video, then changing global parameters.</p>
+    <pre></pre>
+    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/y9trGgqFu_k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</body>
+
+<script>
+    var pre = document.querySelector('pre');
+    
+    var applyHash = function() {
+        const hashValue = window.location.hash.substr(1);
+        pre.textContent = hashValue;
+        searchParams = new URLSearchParams(hashValue);
+        searchParams.forEach(function(value, key) {
+            console.log(key, value);
+        });
+    }
+
+    window.onhashchange = applyHash;
+    applyHash();
+</script>
+</html>

--- a/public/embed-test.html
+++ b/public/embed-test.html
@@ -6,21 +6,27 @@
 </head>
 
 <body>
-    <p>The page won't reload when passing global parameters via the url hash. You can verify this by playing the embedded YouTube video, then changing global parameters.</p>
+    <p>I am an iFrame of the page located at <a href="http://neodash.graphapp.io/embed-test.html" target="_blank">http://neodash.graphapp.io/embed-test.html</a></p> 
+    <p>I'm embedded directly into a dashboard, and dynamically passed the user-made parameter selections.</p>
+    <p>I will not refresh when selections are updated, but, I can see variables change.</p>
+    <p>You can use me to embed external visualizations that are updated together with other charts.</p>
+    <b>Your dashboard variables:</b>
     <pre></pre>
-    <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/y9trGgqFu_k" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</body>
+    <p>
+ </body>
 
 <script>
     var pre = document.querySelector('pre');
     
     var applyHash = function() {
         const hashValue = window.location.hash.substr(1);
-        pre.textContent = hashValue;
+        var output = "";
+
         searchParams = new URLSearchParams(hashValue);
         searchParams.forEach(function(value, key) {
-            console.log(key, value);
+            output += key + ": " + value + "\n"
         });
+        pre.textContent = output;
     }
 
     window.onhashchange = applyHash;

--- a/src/chart/IFrameChart.tsx
+++ b/src/chart/IFrameChart.tsx
@@ -9,6 +9,7 @@ const NeoIFrameChart = (props: ChartProps) => {
     const [extraRecords, setExtraRecords] = React.useState([]);
     // Records are overridden to be a single element array with a field called 'input'.
     const records = props.records;
+    const passGlobalParameters = props?.settings?.passGlobalParameters
     const url = records[0]["input"];
 
     if (!url || !(url.startsWith("http://") || url.startsWith("https://"))) {
@@ -16,9 +17,8 @@ const NeoIFrameChart = (props: ChartProps) => {
     }
 
     const mapParameters = records[0]["mapParameters"] || {};
-    const key = props?.settings?.hashParameter;
-    const value = mapParameters[key];
-    return <iframe style={{ width: "100%", border: "none", marginBottom: "-5px", height: "100%", overflow: "hidden" }} src={url + (value ? "#" + value : "")} />;
+    const queryString = Object.keys(mapParameters).map(key => key + '=' + mapParameters[key]).join('&');
+    return <iframe style={{ width: "100%", border: "none", marginBottom: "-5px", height: "100%", overflow: "hidden" }} src={url + (passGlobalParameters ? "#" + queryString : "")} />;
 }
 
 export default NeoIFrameChart;

--- a/src/chart/IFrameChart.tsx
+++ b/src/chart/IFrameChart.tsx
@@ -1,21 +1,24 @@
 
 import React from 'react';
 import { ChartProps } from './Chart';
-import ReactMarkdown from 'react-markdown';
-import gfm from 'remark-gfm';
 
 /**
  * Renders an iFrame provided by the user.
  */
 const NeoIFrameChart = (props: ChartProps) => {
+    const [extraRecords, setExtraRecords] = React.useState([]);
     // Records are overridden to be a single element array with a field called 'input'.
     const records = props.records;
     const url = records[0]["input"];
-    if (url && (url.startsWith("http://") || url.startsWith("https://"))){
-        return <iframe style={{width: "100%", border: "none", marginBottom: "-5px", height: "100%", overflow: "hidden"}} src={url}/>;
-    }else{
-        return <p style={{margin: "15px"}}>Invalid iFrame URL. Make sure your url starts with <code>http://</code> or <code>https://</code>.</p>
+
+    if (!url || !(url.startsWith("http://") || url.startsWith("https://"))) {
+        return <p style={{ margin: "15px" }}>Invalid iFrame URL. Make sure your url starts with <code>http://</code> or <code>https://</code>.</p>
     }
+
+    const mapParameters = records[0]["mapParameters"] || {};
+    const key = props?.settings?.hashParameter;
+    const value = mapParameters[key];
+    return <iframe style={{ width: "100%", border: "none", marginBottom: "-5px", height: "100%", overflow: "hidden" }} src={url + (value ? "#" + value : "")} />;
 }
 
 export default NeoIFrameChart;

--- a/src/chart/ParameterSelectionChart.tsx
+++ b/src/chart/ParameterSelectionChart.tsx
@@ -10,7 +10,6 @@ import Autocomplete from '@material-ui/lab/Autocomplete';
  * Renders Neo4j records as their JSON representation.
  */
 const NeoParameterSelectionChart = (props: ChartProps) => {
-
     try{
         useEffect(() => {
             debouncedQueryCallback && debouncedQueryCallback(query, { input: inputText }, setExtraRecords);
@@ -30,18 +29,19 @@ const NeoParameterSelectionChart = (props: ChartProps) => {
         [],
     );
 
-
+    
     const records = props.records;
     const query = records[0]["input"];
-
+ 
     if (!query) {
         return <p style={{margin: "15px"}}>No selection specified. Open up the report settings and choose a node label and property.</p>
     }
-
+   
     const parameter = query.split("\n")[0].split("$")[1];
     const label = query.split("`")[1] ? query.split("`")[1] : "";
     const property = query.split("`")[3] ? query.split("`")[3] : "";
 
+    
     return <div>
         <Autocomplete
             id="autocomplete"

--- a/src/chart/ParameterSelectionChart.tsx
+++ b/src/chart/ParameterSelectionChart.tsx
@@ -10,38 +10,40 @@ import Autocomplete from '@material-ui/lab/Autocomplete';
  * Renders Neo4j records as their JSON representation.
  */
 const NeoParameterSelectionChart = (props: ChartProps) => {
-    try{
-        useEffect(() => {
-            debouncedQueryCallback && debouncedQueryCallback(query, { input: inputText }, setExtraRecords);
-        }, [inputText, query]);    
-    }catch(e){
-        
-    }
 
-    const settings = (props.settings) ? props.settings : {};
-    const clearParameterOnFieldClear = settings.clearParameterOnFieldClear;
+    useEffect(() => {
+        debouncedQueryCallback && debouncedQueryCallback(query, { input: inputText }, setExtraRecords);
+    }, [inputText, query]);
 
-    const [extraRecords, setExtraRecords] = React.useState([]);
-    const [inputText, setInputText] = React.useState("");
-    const [value, setValue] = React.useState("");
     const debouncedQueryCallback = useCallback(
         debounce(props.queryCallback, 250),
         [],
     );
-
-    
     const records = props.records;
-    const query = records[0]["input"];
- 
-    if (!query) {
-        return <p style={{margin: "15px"}}>No selection specified. Open up the report settings and choose a node label and property.</p>
+    const query = records[0]["input"] ? records[0]["input"] : undefined;
+    const parameter = query ? query.split("\n")[0].split("$")[1] : "$";
+    
+    const currentValue = (props.getGlobalParameter && props.getGlobalParameter(parameter)) ? props.getGlobalParameter(parameter) : "";
+    const [extraRecords, setExtraRecords] = React.useState([]);
+    const [inputText, setInputText] = React.useState(currentValue);
+    const [value, setValue] = React.useState(currentValue);
+    
+    // In case the components gets (re)loaded with a different/non-existing selected parameter, set the text to the current global parameter value.
+    if(query && value != currentValue && currentValue != inputText ){
+        setValue(currentValue);
+        setInputText(currentValue);
+        setExtraRecords([]);
     }
-   
-    const parameter = query.split("\n")[0].split("$")[1];
+    if (!query || query.trim().length == 0) {
+        return <p style={{ margin: "15px" }}>No selection specified. Open up the report settings and choose a node label and property.</p>
+    }
+
     const label = query.split("`")[1] ? query.split("`")[1] : "";
     const property = query.split("`")[3] ? query.split("`")[3] : "";
-
     
+    const settings = (props.settings) ? props.settings : {};
+    const clearParameterOnFieldClear = settings.clearParameterOnFieldClear;
+
     return <div>
         <Autocomplete
             id="autocomplete"
@@ -51,14 +53,14 @@ const NeoParameterSelectionChart = (props: ChartProps) => {
             inputValue={inputText}
             onInputChange={(event, value) => {
                 setInputText(value);
-                debouncedQueryCallback(query, {input: value}, setExtraRecords);
+                debouncedQueryCallback(query, { input: value }, setExtraRecords);
             }}
-            value={value ? value.toString() : ""}
+            value={value ? value.toString() : currentValue}
             onChange={(event, newValue) => {
                 setValue(newValue);
-                if(newValue == null && clearParameterOnFieldClear){
+                if (newValue == null && clearParameterOnFieldClear) {
                     props.setGlobalParameter(parameter, undefined);
-                }else{
+                } else {
                     props.setGlobalParameter(parameter, newValue);
                 }
             }}

--- a/src/chart/ParameterSelectionChart.tsx
+++ b/src/chart/ParameterSelectionChart.tsx
@@ -1,73 +1,88 @@
+
 import React, { useCallback, useEffect } from 'react';
 import { ChartProps } from './Chart';
 import { debounce, TextareaAutosize, TextField } from '@material-ui/core';
 import { QueryStatus, runCypherQuery } from "../report/CypherQueryRunner";
 import NeoFieldSelection from '../component/FieldSelection';
 import Autocomplete from '@material-ui/lab/Autocomplete';
-
 /**
  * Renders Neo4j records as their JSON representation.
  */
 const NeoParameterSelectionChart = (props: ChartProps) => {
+    try{
+        useEffect(() => {
+            debouncedQueryCallback && debouncedQueryCallback(query, { input: inputText }, setExtraRecords);
+        }, [inputText, query]);    
+    }catch(e){
 
-    useEffect(() => {
-        debouncedQueryCallback && debouncedQueryCallback(query, { input: inputText }, setExtraRecords);
-    }, [inputText, query]);
+    }
 
+    const settings = (props.settings) ? props.settings : {};
+    const clearParameterOnFieldClear = settings.clearParameterOnFieldClear;
+
+    const [extraRecords, setExtraRecords] = React.useState([]);
+    const [inputText, setInputText] = React.useState("");
+    const [value, setValue] = React.useState("");
     const debouncedQueryCallback = useCallback(
         debounce(props.queryCallback, 250),
         [],
     );
+
+
     const records = props.records;
-    const query = records[0]["input"] ? records[0]["input"] : undefined;
-    const parameter = query ? query.split("\n")[0].split("$")[1] : "$";
-    
-    const currentValue = (props.getGlobalParameter && props.getGlobalParameter(parameter)) ? props.getGlobalParameter(parameter) : "";
-    const [extraRecords, setExtraRecords] = React.useState([]);
-    const [inputText, setInputText] = React.useState(currentValue);
-    const [value, setValue] = React.useState(currentValue);
-    
-    // In case the components gets (re)loaded with a different/non-existing selected parameter, set the text to the current global parameter value.
-    if(query && value != currentValue && currentValue != inputText ){
-    
-        setValue(currentValue);
-        setInputText(currentValue);
-        setExtraRecords([]);
-    }
-    if (!query || query.trim().length == 0) {
-        return <p style={{ margin: "15px" }}>No selection specified. Open up the report settings and choose a node label and property.</p>
+    const query = records[0]["input"];
+
+    if (!query) {
+        return <p style={{margin: "15px"}}>No selection specified. Open up the report settings and choose a node label and property.</p>
     }
 
+    const parameter = query.split("\n")[0].split("$")[1];
     const label = query.split("`")[1] ? query.split("`")[1] : "";
     const property = query.split("`")[3] ? query.split("`")[3] : "";
-    
-    const settings = (props.settings) ? props.settings : {};
-    const clearParameterOnFieldClear = settings.clearParameterOnFieldClear;
+
 
     return <div>
         <Autocomplete
             id="autocomplete"
+
+    
+        
+          
+    
+
+        
+    
+    @@ -51,14 +54,14 @@ const NeoParameterSelectionChart = (props: ChartProps) => {
+  
             options={extraRecords.map(r => r["_fields"] && r["_fields"][0] !== null ? r["_fields"][0] : "(no data)")}
             getOptionLabel={(option) => option ? option.toString() : ""}
             style={{ width: 300, marginLeft: "15px", marginTop: "5px" }}
             inputValue={inputText}
             onInputChange={(event, value) => {
                 setInputText(value);
-                debouncedQueryCallback(query, { input: value }, setExtraRecords);
+                debouncedQueryCallback(query, {input: value}, setExtraRecords);
             }}
-            value={value ? value.toString() : currentValue}
+            value={value ? value.toString() : ""}
             onChange={(event, newValue) => {
                 setValue(newValue);
-                if (newValue == null && clearParameterOnFieldClear) {
+                if(newValue == null && clearParameterOnFieldClear){
                     props.setGlobalParameter(parameter, undefined);
-                } else {
+                }else{
                     props.setGlobalParameter(parameter, newValue);
                 }
             }}
+
+    
+          
+            
+    
+
+          
+    
+    
+  
             renderInput={(params) => <TextField {...params} InputLabelProps={{ shrink: true }} placeholder="Start typing..." label={label + " " + property} variant="outlined" />}
         />
-
     </div>
 }
-
 export default NeoParameterSelectionChart;

--- a/src/chart/ParameterSelectionChart.tsx
+++ b/src/chart/ParameterSelectionChart.tsx
@@ -15,7 +15,7 @@ const NeoParameterSelectionChart = (props: ChartProps) => {
             debouncedQueryCallback && debouncedQueryCallback(query, { input: inputText }, setExtraRecords);
         }, [inputText, query]);    
     }catch(e){
-
+        
     }
 
     const settings = (props.settings) ? props.settings : {};

--- a/src/chart/ParameterSelectionChart.tsx
+++ b/src/chart/ParameterSelectionChart.tsx
@@ -11,39 +11,36 @@ import Autocomplete from '@material-ui/lab/Autocomplete';
  */
 const NeoParameterSelectionChart = (props: ChartProps) => {
 
-    useEffect(() => {
-        debouncedQueryCallback && debouncedQueryCallback(query, { input: inputText }, setExtraRecords);
-    }, [inputText, query]);
+    try{
+        useEffect(() => {
+            debouncedQueryCallback && debouncedQueryCallback(query, { input: inputText }, setExtraRecords);
+        }, [inputText, query]);    
+    }catch(e){
 
+    }
+
+    const settings = (props.settings) ? props.settings : {};
+    const clearParameterOnFieldClear = settings.clearParameterOnFieldClear;
+
+    const [extraRecords, setExtraRecords] = React.useState([]);
+    const [inputText, setInputText] = React.useState("");
+    const [value, setValue] = React.useState("");
     const debouncedQueryCallback = useCallback(
         debounce(props.queryCallback, 250),
         [],
     );
+
+
     const records = props.records;
-    const query = records[0]["input"] ? records[0]["input"] : undefined;
-    const parameter = query ? query.split("\n")[0].split("$")[1] : "$";
-    
-    const currentValue = (props.getGlobalParameter && props.getGlobalParameter(parameter)) ? props.getGlobalParameter(parameter) : "";
-    const [extraRecords, setExtraRecords] = React.useState([]);
-    const [inputText, setInputText] = React.useState(currentValue);
-    const [value, setValue] = React.useState(currentValue);
-    
-    // In case the components gets (re)loaded with a different/non-existing selected parameter, set the text to the current global parameter value.
-    if(query && value != currentValue && currentValue != inputText ){
-    
-        setValue(currentValue);
-        setInputText(currentValue);
-        setExtraRecords([]);
-    }
-    if (!query || query.trim().length == 0) {
-        return <p style={{ margin: "15px" }}>No selection specified. Open up the report settings and choose a node label and property.</p>
+    const query = records[0]["input"];
+
+    if (!query) {
+        return <p style={{margin: "15px"}}>No selection specified. Open up the report settings and choose a node label and property.</p>
     }
 
+    const parameter = query.split("\n")[0].split("$")[1];
     const label = query.split("`")[1] ? query.split("`")[1] : "";
     const property = query.split("`")[3] ? query.split("`")[3] : "";
-    
-    const settings = (props.settings) ? props.settings : {};
-    const clearParameterOnFieldClear = settings.clearParameterOnFieldClear;
 
     return <div>
         <Autocomplete
@@ -54,14 +51,14 @@ const NeoParameterSelectionChart = (props: ChartProps) => {
             inputValue={inputText}
             onInputChange={(event, value) => {
                 setInputText(value);
-                debouncedQueryCallback(query, { input: value }, setExtraRecords);
+                debouncedQueryCallback(query, {input: value}, setExtraRecords);
             }}
-            value={value ? value.toString() : currentValue}
+            value={value ? value.toString() : ""}
             onChange={(event, newValue) => {
                 setValue(newValue);
-                if (newValue == null && clearParameterOnFieldClear) {
+                if(newValue == null && clearParameterOnFieldClear){
                     props.setGlobalParameter(parameter, undefined);
-                } else {
+                }else{
                     props.setGlobalParameter(parameter, newValue);
                 }
             }}

--- a/src/chart/ParameterSelectionChart.tsx
+++ b/src/chart/ParameterSelectionChart.tsx
@@ -1,4 +1,3 @@
-
 import React, { useCallback, useEffect } from 'react';
 import { ChartProps } from './Chart';
 import { debounce, TextareaAutosize, TextField } from '@material-ui/core';

--- a/src/chart/ParameterSelectionChart.tsx
+++ b/src/chart/ParameterSelectionChart.tsx
@@ -15,7 +15,7 @@ const NeoParameterSelectionChart = (props: ChartProps) => {
             debouncedQueryCallback && debouncedQueryCallback(query, { input: inputText }, setExtraRecords);
         }, [inputText, query]);    
     }catch(e){
-        
+
     }
 
     const settings = (props.settings) ? props.settings : {};
@@ -41,7 +41,7 @@ const NeoParameterSelectionChart = (props: ChartProps) => {
     const label = query.split("`")[1] ? query.split("`")[1] : "";
     const property = query.split("`")[3] ? query.split("`")[3] : "";
 
-
+    
     return <div>
         <Autocomplete
             id="autocomplete"

--- a/src/chart/ParameterSelectionChart.tsx
+++ b/src/chart/ParameterSelectionChart.tsx
@@ -15,7 +15,7 @@ const NeoParameterSelectionChart = (props: ChartProps) => {
             debouncedQueryCallback && debouncedQueryCallback(query, { input: inputText }, setExtraRecords);
         }, [inputText, query]);    
     }catch(e){
-
+        
     }
 
     const settings = (props.settings) ? props.settings : {};
@@ -41,7 +41,7 @@ const NeoParameterSelectionChart = (props: ChartProps) => {
     const label = query.split("`")[1] ? query.split("`")[1] : "";
     const property = query.split("`")[3] ? query.split("`")[3] : "";
 
-    
+
     return <div>
         <Autocomplete
             id="autocomplete"

--- a/src/chart/ParameterSelectionChart.tsx
+++ b/src/chart/ParameterSelectionChart.tsx
@@ -30,6 +30,7 @@ const NeoParameterSelectionChart = (props: ChartProps) => {
     
     // In case the components gets (re)loaded with a different/non-existing selected parameter, set the text to the current global parameter value.
     if(query && value != currentValue && currentValue != inputText ){
+    
         setValue(currentValue);
         setInputText(currentValue);
         setExtraRecords([]);

--- a/src/chart/ParameterSelectionChart.tsx
+++ b/src/chart/ParameterSelectionChart.tsx
@@ -5,84 +5,70 @@ import { debounce, TextareaAutosize, TextField } from '@material-ui/core';
 import { QueryStatus, runCypherQuery } from "../report/CypherQueryRunner";
 import NeoFieldSelection from '../component/FieldSelection';
 import Autocomplete from '@material-ui/lab/Autocomplete';
+
 /**
  * Renders Neo4j records as their JSON representation.
  */
 const NeoParameterSelectionChart = (props: ChartProps) => {
-    try{
-        useEffect(() => {
-            debouncedQueryCallback && debouncedQueryCallback(query, { input: inputText }, setExtraRecords);
-        }, [inputText, query]);    
-    }catch(e){
 
-    }
+    useEffect(() => {
+        debouncedQueryCallback && debouncedQueryCallback(query, { input: inputText }, setExtraRecords);
+    }, [inputText, query]);
 
-    const settings = (props.settings) ? props.settings : {};
-    const clearParameterOnFieldClear = settings.clearParameterOnFieldClear;
-
-    const [extraRecords, setExtraRecords] = React.useState([]);
-    const [inputText, setInputText] = React.useState("");
-    const [value, setValue] = React.useState("");
     const debouncedQueryCallback = useCallback(
         debounce(props.queryCallback, 250),
         [],
     );
-
-
     const records = props.records;
-    const query = records[0]["input"];
-
-    if (!query) {
-        return <p style={{margin: "15px"}}>No selection specified. Open up the report settings and choose a node label and property.</p>
+    const query = records[0]["input"] ? records[0]["input"] : undefined;
+    const parameter = query ? query.split("\n")[0].split("$")[1] : "$";
+    
+    const currentValue = (props.getGlobalParameter && props.getGlobalParameter(parameter)) ? props.getGlobalParameter(parameter) : "";
+    const [extraRecords, setExtraRecords] = React.useState([]);
+    const [inputText, setInputText] = React.useState(currentValue);
+    const [value, setValue] = React.useState(currentValue);
+    
+    // In case the components gets (re)loaded with a different/non-existing selected parameter, set the text to the current global parameter value.
+    if(query && value != currentValue && currentValue != inputText ){
+    
+        setValue(currentValue);
+        setInputText(currentValue);
+        setExtraRecords([]);
+    }
+    if (!query || query.trim().length == 0) {
+        return <p style={{ margin: "15px" }}>No selection specified. Open up the report settings and choose a node label and property.</p>
     }
 
-    const parameter = query.split("\n")[0].split("$")[1];
     const label = query.split("`")[1] ? query.split("`")[1] : "";
     const property = query.split("`")[3] ? query.split("`")[3] : "";
-
+    
+    const settings = (props.settings) ? props.settings : {};
+    const clearParameterOnFieldClear = settings.clearParameterOnFieldClear;
 
     return <div>
         <Autocomplete
             id="autocomplete"
-
-    
-        
-          
-    
-
-        
-    
-    @@ -51,14 +54,14 @@ const NeoParameterSelectionChart = (props: ChartProps) => {
-  
             options={extraRecords.map(r => r["_fields"] && r["_fields"][0] !== null ? r["_fields"][0] : "(no data)")}
             getOptionLabel={(option) => option ? option.toString() : ""}
             style={{ width: 300, marginLeft: "15px", marginTop: "5px" }}
             inputValue={inputText}
             onInputChange={(event, value) => {
                 setInputText(value);
-                debouncedQueryCallback(query, {input: value}, setExtraRecords);
+                debouncedQueryCallback(query, { input: value }, setExtraRecords);
             }}
-            value={value ? value.toString() : ""}
+            value={value ? value.toString() : currentValue}
             onChange={(event, newValue) => {
                 setValue(newValue);
-                if(newValue == null && clearParameterOnFieldClear){
+                if (newValue == null && clearParameterOnFieldClear) {
                     props.setGlobalParameter(parameter, undefined);
-                }else{
+                } else {
                     props.setGlobalParameter(parameter, newValue);
                 }
             }}
-
-    
-          
-            
-    
-
-          
-    
-    
-  
             renderInput={(params) => <TextField {...params} InputLabelProps={{ shrink: true }} placeholder="Start typing..." label={label + " " + property} variant="outlined" />}
         />
+
     </div>
 }
+
 export default NeoParameterSelectionChart;

--- a/src/config/ExampleConfig.tsx
+++ b/src/config/ExampleConfig.tsx
@@ -1,5 +1,7 @@
 import NeoBarChart from "../chart/BarChart";
 import NeoGraphChart from "../chart/GraphChart";
+import NeoIFrameChart from "../chart/IFrameChart";
+import NeoJSONChart from "../chart/JSONChart";
 import NeoLineChart from "../chart/LineChart";
 import NeoMapChart from "../chart/MapChart";
 import NeoTableChart from "../chart/TableChart";
@@ -202,5 +204,17 @@ RETURN value
         selection: {},
         type: "map",
         chartType: NeoMapChart
+    },
+    {
+        title: "iFrame",
+        description: "You can iFrame other webpages inside a dashboard, and dynamically pass in your dashboard parameters into the URL.",
+        exampleQuery: `http://neodash.graphapp.io/embed-test.html`,
+        syntheticQuery: `http://localhost:3000/embed-test.html`,
+        settings: {"passGlobalParameters": true},
+        fields: [],
+        globalParameters: {"neodash_person_name": "Keanu", "neodash_movie_title": "The Matrix"},
+        selection: {},
+        type: "iframe",
+        chartType: NeoIFrameChart
     }
 ]

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -490,10 +490,11 @@ export const REPORT_TYPES = {
         maxRecords: 1,
         allowScrolling: true,
         settings: {
-            "hashParameter": {
-                label: "Parameter Select Property (without $ in front) to pass to iframe via hash parameter",
-                type: SELECTION_TYPES.TEXT,
-                default: undefined
+            "passGlobalParameters": {
+                label: "Pass global variables to iframe via hash parameter. For example: http://example.com#neodash_person_name=Niels&neodash_company_name=Neo4j.",
+                type: SELECTION_TYPES.LIST,
+                values: [true, false],
+                default: false
             }
         }
     },

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -491,7 +491,7 @@ export const REPORT_TYPES = {
         allowScrolling: true,
         settings: {
             "passGlobalParameters": {
-                label: "Pass global variables to iframe via hash parameter. For example: http://example.com#neodash_person_name=Niels&neodash_company_name=Neo4j.",
+                label: "Pass global variables to iFrame URL",
                 type: SELECTION_TYPES.LIST,
                 values: [true, false],
                 default: false

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -489,7 +489,13 @@ export const REPORT_TYPES = {
         inputMode: "url",
         maxRecords: 1,
         allowScrolling: true,
-        settings: {}
+        settings: {
+            "hashParameter": {
+                label: "Parameter Select Property (without $ in front) to pass to iframe via hash parameter",
+                type: SELECTION_TYPES.TEXT,
+                default: undefined
+            }
+        }
     },
     "text": {
         label: "Markdown",

--- a/src/modal/DocumentationModal.tsx
+++ b/src/modal/DocumentationModal.tsx
@@ -45,42 +45,47 @@ export const NeoDocumentationModal = ({ database }) => {
                     </IconButton>
                 </DialogTitle>
                 <div>
-                <DialogContent >
-                    <hr></hr>
-                    {EXAMPLE_REPORTS.map(example => {
-                        return <>
-                            <h3>{example.title}</h3>
-                            <DialogContentText>{example.description}
-                            <br/>
-                            <br/>
-                            <Grid container spacing={4}>
-                                <Grid item xs={4}>
-                                    <div style={{  width: "400px", border: "0px solid lightgrey" }} >
-                                        <NeoEditableCodeField editable={false} placeholder="" value={example.exampleQuery}></NeoEditableCodeField>
-                                    </div>
-                                </Grid>
+                    <DialogContent >
+                        <hr></hr>
+                        {EXAMPLE_REPORTS.map(example => {
+                            return <>
+                                <h3>{example.title}</h3>
+                                <DialogContentText>{example.description}
+                                    <br />
+                                    <br />
+                                    <Grid container spacing={4}>
+                                        <Grid item xs={4}>
+                                            <div style={{ width: "400px", border: "0px solid lightgrey" }} >
+                                                <NeoEditableCodeField editable={false}
+                                                    placeholder=""
+                                                    value={example.exampleQuery}
+                                                    language={example.type == "iframe" ? "url" : "cypher"}
+                                                ></NeoEditableCodeField>
+                                            </div>
+                                        </Grid>
 
-                                <Grid item xs={8}>
-                                    <div style={{ height: "355px", width: "800px", overflow: "hidden", border: "1px solid lightgrey" }} >
-                                        <NeoReport
-                                            query={example.syntheticQuery}
-                                            database={database}
-                                            disabled={!open}
-                                            selection={example.selection}
-                                            settings={example.settings}
-                                            fields={example.fields}
-                                            dimensions={example.dimensions}
-                                            ChartType={example.chartType}
-                                            type = {example.type}
-                                        />
-                                    </div>
-                                </Grid>
-                            </Grid>
-                            </DialogContentText>
-                            <hr></hr>
-                        </>
-                    })}
-                </DialogContent>
+                                        <Grid item xs={8}>
+                                            <div style={{ height: "355px", width: "800px", overflow: "hidden", border: "1px solid lightgrey" }} >
+                                                <NeoReport
+                                                    query={example.syntheticQuery}
+                                                    database={database}
+                                                    disabled={!open}
+                                                    selection={example.selection}
+                                                    mapParameters={example.globalParameters}
+                                                    settings={example.settings}
+                                                    fields={example.fields}
+                                                    dimensions={example.dimensions}
+                                                    ChartType={example.chartType}
+                                                    type={example.type}
+                                                />
+                                            </div>
+                                        </Grid>
+                                    </Grid>
+                                </DialogContentText>
+                                <hr></hr>
+                            </>
+                        })}
+                    </DialogContent>
                 </div>
             </Dialog> : <></>}
         </div>

--- a/src/report/Report.tsx
+++ b/src/report/Report.tsx
@@ -46,7 +46,7 @@ export const NeoReport = ({
         // If this is a 'text-only' report, no queries are ran, instead we pass the input directly to the report.
         if (REPORT_TYPES[type].textOnly) {
             setStatus(QueryStatus.COMPLETE);
-            setRecords([{ input: query }]);
+            setRecords([{ input: query, mapParameters: mapParameters }]);
             return;
         }
 


### PR DESCRIPTION
Copy paste the parameter select variable (e.g. `neodash_entity_name`) into the advanced settings of the iframe chart. Then see the magic happening via inspect element on the iframe. The hash value changes when you choose the value via parameter select chart, without re-rendering the iframe. Re-rendering iframe could be jarring and state could be lost, so it's important to ensure the chart doesn't re-render during these updates. Page within iframe can access value of `window.location.hash` and setup a listener to be notified of changes.