### PR TITLE
Graph modal

### DIFF
--- a/src/chart/GraphChart.tsx
+++ b/src/chart/GraphChart.tsx
@@ -7,7 +7,7 @@ import { schemeCategory10, schemeAccent, schemeDark2, schemePaired, schemePastel
 import { categoricalColorSchemes } from '../config/ColorConfig';
 import { ChartProps } from './Chart';
 import { valueIsArray, valueIsNode, valueIsRelationship, valueIsPath } from '../report/RecordProcessing';
-import { NeoGraphModal } from '../modal/GraphModal';
+import { NeoGraphItemInspectModal } from '../modal/GraphItemInspectModal';
 
 const update = (state, mutations) =>
     Object.assign({}, state, mutations)
@@ -20,7 +20,7 @@ const NeoGraphChart = (props: ChartProps) => {
     }
 
     const [open, setOpen] = React.useState(false);
-    const [modalItem, setModalItem] = React.useState({});
+    const [inspectItem, setInspectItem] = React.useState({});
 
     const handleOpen = () => {
         setOpen(true);
@@ -44,6 +44,8 @@ const NeoGraphChart = (props: ChartProps) => {
     const relLabelFontSize = props.settings && props.settings.relLabelFontSize ? props.settings.relLabelFontSize : 2.75;
     const relLabelColor = props.settings && props.settings.relLabelColor ? props.settings.relLabelColor : "#909090";
     const nodeColorScheme = props.settings && props.settings.nodeColorScheme ? props.settings.nodeColorScheme : "neodash";
+    const showPropertiesOnHover = props.settings && props.settings.showPropertiesOnHover !== undefined ? props.settings.showPropertiesOnHover : true;
+    const showPropertiesOnClick = props.settings && props.settings.showPropertiesOnClick !== undefined ? props.settings.showPropertiesOnClick : true;
     const selfLoopRotationDegrees = 45;
     const rightClickToExpandNodes = false; // TODO - this isn't working properly yet, disable it.
     const defaultNodeColor = "lightgrey"; // Color of nodes without labels
@@ -194,9 +196,10 @@ const NeoGraphChart = (props: ChartProps) => {
     }, []);
 
     const showPopup = useCallback(item => {
-        console.log(item);
-        setModalItem(item);
-        handleOpen();
+        if(showPropertiesOnClick){
+            setInspectItem(item);
+            handleOpen();
+        }
     }, []);
 
     // If the set of extra records gets updated (e.g. on relationship expand), rebuild the graph.
@@ -215,8 +218,8 @@ const NeoGraphChart = (props: ChartProps) => {
                 linkDirectionalArrowLength={3}
                 linkDirectionalArrowRelPos={1}
                 linkWidth={link => link.width}
-                linkLabel={link => `<div>${generateTooltip(link)}</div>`}
-                nodeLabel={node => `<div>${generateTooltip(node)}</div>`}
+                linkLabel={link => showPropertiesOnHover ? `<div>${generateTooltip(link)}</div>` : ""}
+                nodeLabel={node => showPropertiesOnHover ? `<div>${generateTooltip(node)}</div>` : ""}
                 nodeVal={node => node.size}
                 onNodeClick={showPopup}
                 onLinkClick={showPopup}
@@ -264,7 +267,7 @@ const NeoGraphChart = (props: ChartProps) => {
                 }}
                 graphData={width ? data : { nodes: [], links: [] }}
             />
-            <NeoGraphModal open={open} handleClose={handleClose} title={modalItem.lastLabel || modalItem.type} object={modalItem.properties}></NeoGraphModal>
+            <NeoGraphItemInspectModal open={open} handleClose={handleClose} title={(inspectItem.labels && inspectItem.labels.join(", ")) || inspectItem.type} object={inspectItem.properties}></NeoGraphItemInspectModal>
         </div>
     );
 }

--- a/src/chart/GraphChart.tsx
+++ b/src/chart/GraphChart.tsx
@@ -7,7 +7,7 @@ import { schemeCategory10, schemeAccent, schemeDark2, schemePaired, schemePastel
 import { categoricalColorSchemes } from '../config/ColorConfig';
 import { ChartProps } from './Chart';
 import { valueIsArray, valueIsNode, valueIsRelationship, valueIsPath } from '../report/RecordProcessing';
-
+import { NeoGraphModal } from '../modal/GraphModal';
 
 const update = (state, mutations) =>
     Object.assign({}, state, mutations)
@@ -18,6 +18,17 @@ const NeoGraphChart = (props: ChartProps) => {
     if (props.records == null || props.records.length == 0 || props.records[0].keys == null) {
         return <>No data, re-run the report.</>
     }
+
+    const [open, setOpen] = React.useState(false);
+    const [modalItem, setModalItem] = React.useState({});
+
+    const handleOpen = () => {
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
 
     // Retrieve config from advanced settings
     const backgroundColor = props.settings && props.settings.backgroundColor ? props.settings.backgroundColor : "#fafafa";
@@ -177,11 +188,16 @@ const NeoGraphChart = (props: ChartProps) => {
     }
 
     const handleExpand = useCallback(node => {
-        if(rightClickToExpandNodes){
+        if (rightClickToExpandNodes) {
             props.queryCallback && props.queryCallback("MATCH (n)-[e]-(m) WHERE id(n) =" + node.id + " RETURN e,m", {}, setExtraRecords);
         }
     }, []);
 
+    const showPopup = useCallback(item => {
+        console.log(item);
+        setModalItem(item);
+        handleOpen();
+    }, []);
 
     // If the set of extra records gets updated (e.g. on relationship expand), rebuild the graph.
     useEffect(() => {
@@ -202,6 +218,8 @@ const NeoGraphChart = (props: ChartProps) => {
                 linkLabel={link => `<div>${generateTooltip(link)}</div>`}
                 nodeLabel={node => `<div>${generateTooltip(node)}</div>`}
                 nodeVal={node => node.size}
+                onNodeClick={showPopup}
+                onLinkClick={showPopup}
                 onNodeRightClick={handleExpand}
                 nodeCanvasObjectMode={() => "after"}
                 nodeCanvasObject={(node, ctx, globalScale) => {
@@ -246,6 +264,7 @@ const NeoGraphChart = (props: ChartProps) => {
                 }}
                 graphData={width ? data : { nodes: [], links: [] }}
             />
+            <NeoGraphModal open={open} handleClose={handleClose} title={modalItem.lastLabel || modalItem.type} object={modalItem.properties}></NeoGraphModal>
         </div>
     );
 }

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -129,6 +129,18 @@ export const REPORT_TYPES = {
                 type: SELECTION_TYPES.TEXT,
                 default: "#fafafa"
             },
+            "showPropertiesOnHover": {
+                label: "Show pop-up on Hover",
+                type: SELECTION_TYPES.LIST,
+                values: [true, false],
+                default: true
+            },
+            "showPropertiesOnClick": {
+                label: "Show properties on Click",
+                type: SELECTION_TYPES.LIST,
+                values: [true, false],
+                default: true
+            },
             "hideSelections": {
                 label: "Hide Property Selection",
                 type: SELECTION_TYPES.LIST,

--- a/src/modal/GraphItemInspectModal.tsx
+++ b/src/modal/GraphItemInspectModal.tsx
@@ -19,13 +19,13 @@ const formatProperty = (property) => {
     return property;
 }
 
-export const NeoGraphModal = ({ open, handleClose, title, object }) => {
+export const NeoGraphItemInspectModal = ({ open, handleClose, title, object }) => {
     return (
         <div>
             <Dialog maxWidth={"lg"} open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">
-                    {title}
-                    <IconButton onClick={handleClose} style={{ padding: "3px", float: "right" }}>
+                    {title} 
+                    <IconButton onClick={handleClose} style={{ padding: "3px", marginLeft: "20px", float: "right" }}>
                         <Badge badgeContent={""} >
                             <CloseIcon />
                         </Badge>
@@ -54,6 +54,6 @@ export const NeoGraphModal = ({ open, handleClose, title, object }) => {
     );
 }
 
-export default (NeoGraphModal);
+export default (NeoGraphItemInspectModal);
 
 

--- a/src/modal/GraphModal.tsx
+++ b/src/modal/GraphModal.tsx
@@ -1,0 +1,59 @@
+
+import React from 'react';
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+import Badge from '@material-ui/core/Badge';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableRow from '@material-ui/core/TableRow';
+
+const formatProperty = (property) => {
+    if (property.startsWith("http://") || property.startsWith("https://")) {
+        return <a href={property}>{property}</a>;
+    }
+    return property;
+}
+
+export const NeoGraphModal = ({ open, handleClose, title, object }) => {
+    return (
+        <div>
+            <Dialog maxWidth={"lg"} open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+                <DialogTitle id="form-dialog-title">
+                    {title}
+                    <IconButton onClick={handleClose} style={{ padding: "3px", float: "right" }}>
+                        <Badge badgeContent={""} >
+                            <CloseIcon />
+                        </Badge>
+                    </IconButton>
+                </DialogTitle>
+                <DialogContent>
+                    {object &&
+                        <TableContainer>
+                            <Table size="small">
+                                <TableBody>
+                                    {Object.keys(object).map((key) => (
+                                        <TableRow key={key}>
+                                            <TableCell component="th" scope="row">
+                                                {key}
+                                            </TableCell>
+                                            <TableCell align="right">{formatProperty(object[key].toString())}</TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                        </TableContainer>
+                    }
+                </DialogContent>
+            </Dialog>
+        </div >
+    );
+}
+
+export default (NeoGraphModal);
+
+


### PR DESCRIPTION
Show modal when clicking node/relation in graph with its properties. This comes in handy when you want to copy/paste values from nodes displayed in the graph (the default tooltip disappears if you try to copy values from there). Also handy in case theres a URL in one of the properties. The URL will be clickable from the modal.

Perhaps not so great for dense graphs, as you may accidentally trigger the modal when dragging within the graph...