### PR TITLE
Support rendering native and custom types in Data Grid

### DIFF
--- a/src/chart/TableChart.tsx
+++ b/src/chart/TableChart.tsx
@@ -85,6 +85,12 @@ const customColumnProperties: any = {
     "string": {
         type: 'string',
         renderCell: (c) => RenderString(c.value),
+    },
+    "null": {
+        type: 'string'
+    },
+    "undefined": {
+        type: 'string'
     }
 };
 

--- a/src/chart/TableChart.tsx
+++ b/src/chart/TableChart.tsx
@@ -107,7 +107,7 @@ function RenderSubValue(value, key = 0) {
 
     const type = getRecordType(value);
     const columnProperties = customColumnProperties[type];
-    if (columnProperties.renderCell) {
+    if (columnProperties?.renderCell) {
         return columnProperties.renderCell({ value: value });
     }
 

--- a/src/chart/TableChart.tsx
+++ b/src/chart/TableChart.tsx
@@ -113,8 +113,13 @@ function RenderSubValue(value, key = 0) {
 
     const type = getRecordType(value);
     const columnProperties = customColumnProperties[type];
-    if (columnProperties?.renderCell) {
-        return columnProperties.renderCell({ value: value });
+
+    if (columnProperties) {
+        if (columnProperties.renderCell) {
+            return columnProperties.renderCell({ value: value });
+        } else if (columnProperties.valueGetter) {
+            return columnProperties.valueGetter({ value: value });
+        }
     }
 
     return RenderString(value);

--- a/src/report/RecordProcessing.tsx
+++ b/src/report/RecordProcessing.tsx
@@ -107,13 +107,13 @@ export function mapSingleRecord(record, fieldLookup, keys, defaultKey,
     if (numericFieldNames.some(numericFieldName => (isNaN(record._fields[record._fieldLookup[numericFieldName]])))) {
         return null;
     }
-  
+
     numericOrDatetimeFieldNames.forEach(numericOrDatetimeFieldName => {
         const value = record._fields[record._fieldLookup[numericOrDatetimeFieldName]];
         const className = value.__proto__.constructor.name;
-        if (className == "DateTime"){
-            record._fields[record._fieldLookup[numericOrDatetimeFieldName]] =new Date(value.toString());
-            
+        if (className == "DateTime") {
+            record._fields[record._fieldLookup[numericOrDatetimeFieldName]] = new Date(value.toString());
+
         }
     })
 
@@ -250,4 +250,34 @@ export function valueIsPath(value) {
 export function valueIsObject(value) {
     const className = value.__proto__.constructor.name;
     return className == "Object";
+}
+
+export function getRecordType(value) {
+    // mui data-grid native column types are: 'string' (default),
+    // 'number', 'date', 'dateTime', 'boolean' and 'singleSelect'
+    // https://v4.mui.com/components/data-grid/columns/#column-types
+    // Type singleSelect is not implemented here
+
+    if (value === true || value === false) {
+        return 'boolean';
+    } else if (value.__isInteger__) {
+        return 'number';
+    } else if (value.__isDate__) {
+        return 'date';
+    } else  if (value.__isDateTime__) {
+        return 'dateTime';
+    } else if (valueIsNode(value)) {
+        return 'node';
+    } else if (valueIsRelationship(value)) {
+        return 'relationship';
+    } else if (valueIsPath(value)) {
+        return 'path';
+    } else if (valueIsArray(value)) {
+        return 'array';
+    } else if (valueIsObject(value)) {
+        return 'object';
+    }
+
+    // Use string as default type
+    return 'string';
 }

--- a/src/report/RecordProcessing.tsx
+++ b/src/report/RecordProcessing.tsx
@@ -260,6 +260,10 @@ export function getRecordType(value) {
 
     if (value === true || value === false) {
         return 'boolean';
+    } else if (value === undefined) {
+        return 'undefined';
+    } else if (value === null) {
+        return 'null';
     } else if (value.__isInteger__) {
         return 'number';
     } else if (value.__isDate__) {


### PR DESCRIPTION
I reworked the way data types are handled in the Data Grid and added support for additional types: `boolean`, `number`, `date` and `datetime`. From the screenshot you can't really tell, but before all types were treated as strings. Which isn't great for filtering and sorting. Now you can filter properly with e.g. numeric comparison or filter cells before/after a certain date. In addition to that, `object` cells are now filterable. An `object` is transformed to a `string` with `JSON.stringify()`. But instead of doing that inside the `renderCell` function, I'm doing it with `valueGetter`, which happens before rendering and the output is used by the filtering and sorting functions. So you can now filter all objects containing the string `key` (which is all of them in this example xD).

<img width="1817" alt="Schermafbeelding 2022-01-04 om 17 51 40" src="https://user-images.githubusercontent.com/94383160/148094407-2e2614d3-9687-4da2-ab8e-6c1331c06881.png">

You can try it out with this example cypher query using the fincen dataset.

```
MATCH Path=(e:Entity)-[:COUNTRY]->(c:Country), (f:Filing)-[r:BENEFITS]->(e)
RETURN e as Node, r as Relationship, Path, e.name as Entity, 10000000000000 as Number, false as Boolean, "https://example.com" as URL, datetime() as DateTime, date() as Date, nodes(Path) as Array, { key: "value" } as Object
LIMIT 20
```

I think this somewhat more modular approach will also make it easier to add additional types in the future.