### PR TITLE
feat(docker): add Dockerfile, wrapper script to build & run

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ To build the app for production:
 - execute `npm run build`. This will create a `build` folder in your project directory.
 - deploy the contents of the build folder to a web server. You should then be able to run the web app.
 
-### Docker
-Use the script under ./tools/neodash-build-run.bash to build multi-stage NeoDash image & access it with nginx:
+### Build and run Docker image
+Make sure you have a recent version of `docker` installed.
+Use the script under `./tools/neodash-build-run.bash` to build the multi-stage NeoDash image & access it with nginx:
 ```
 $ cd tools/
 $ ./neodash-build-run.bash 
 ```
-Then go to http://localhost:8080/ in your browser
+Then go to http://localhost:8080/ in your browser.
 
  ## Extending NeoDash
  As of v2.0, NeoDash is easy to extend with your own visualizations. There are two steps to take to plug in your own charts:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ To build the app for production:
 - execute `npm run build`. This will create a `build` folder in your project directory.
 - deploy the contents of the build folder to a web server. You should then be able to run the web app.
 
+### Docker
+Use the script under ./tools/neodash-build-run.bash to build multi-stage NeoDash image & access it with nginx:
+```
+$ cd tools/
+$ ./neodash-build-run.bash 
+```
+Then go to http://localhost:8080/ in your browser
 
  ## Extending NeoDash
  As of v2.0, NeoDash is easy to extend with your own visualizations. There are two steps to take to plug in your own charts:

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,24 @@
+FROM centos:centos8.3.2011 AS builder
+
+RUN yum install -y epel-release; yum check-update; pwd
+RUN yum install -y rsync git
+
+RUN dnf module list nodejs && dnf module enable -y nodejs:12
+RUN dnf install -y nodejs
+
+RUN git clone -b 2.0.5 https://github.com/nielsdejong/neodash.git /usr/local/src/neodash
+RUN npm install -g typescript
+RUN npm install -g jest
+
+RUN git clone https://github.com/nielsdejong/charts.git /usr/local/src/charts && cd /usr/local/src/charts && git checkout cd8bf3707d48f2c34ec6a1ad126cfd28b5ac3065
+RUN cd /usr/local/src/charts; npm install; npm run build
+WORKDIR /usr/local/src/neodash
+RUN rm -rf node_modules/ && npm install
+RUN cd /usr/local/src/neodash/node_modules/@graphapps/charts; rsync -avP /usr/local/src/charts/* .
+RUN npm run build
+
+
+FROM nginx:mainline AS neodash
+LABEL org.opencontainers.image.authors="kayra.otaner@adp.com"
+WORKDIR /usr/share/nginx/html
+COPY --from=builder /usr/local/src/neodash/build /usr/share/nginx/html

--- a/tools/neodash-build-run.bash
+++ b/tools/neodash-build-run.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker build . -t neodash
+docker run -it --rm -p 8080:80 neodash


### PR DESCRIPTION
I ended up cloning graph-chart from its fork, build it separately and rsync it to node_modules to get it work due to an issue discussed previously. Regardless, it builds and runs.