### PR TITLE
Fix URL to pre-built docker image in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ ./docker-build-run_windows.bash --port=$YOUR_PORT
 ```
 Then visit localhost with the chosen port in your browser.
 
-A pre-built Docker image is available [https://hub.docker.com/r/nielsdejong/neodash](on DockerHub). 
+A pre-built Docker image is available [on DockerHub](https://hub.docker.com/r/nielsdejong/neodash). 
 
  ## Extending NeoDash
  As of v2.0, NeoDash is easy to extend with your own visualizations. There are two steps to take to plug in your own charts:


### PR DESCRIPTION
There is a small markdown typo which results in wrong rendering of the URL in the readme. Just a minor modification to fix that.