### PR TITLE
Stability fixes for 2.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neodash",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "NeoDash - Neo4j Dashboard Builder",
   "neo4jDesktop": {
     "apiVersion": "^1.2.0"

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,8 +1,12 @@
-## NeoDash 2.0.8 / 2.0.9 / 2.0.10
-Fixed to supplement 2.0.7:
+## NeoDash 2.0.8 / 2.0.9 / 2.0.10 / 2.0.11
+Stability fixes to supplement 2.0.7:
 - Hotfix for missing config file in Neo4j Desktop causing startup issue.
 - Hotfix for application crashes caused by rendering custom data types in transposed table views.
 - Hotfix for object rendering in tables & line-chart type detection.
+- Fix for rendering dictionaries in tables/single value charts.
+- Added resize handler for fullscreen map views.
+- Added missing auto-run config to pie charts.
+- Fixed broken value scale parameter for bar charts.
 
 ## NeoDash 2.0.7
 Application functionality:

--- a/src/chart/MapChart.tsx
+++ b/src/chart/MapChart.tsx
@@ -19,7 +19,6 @@ const update = (state, mutations) =>
  * Renders Neo4j records as their JSON representation.
  */
 const NeoMapChart = (props: ChartProps) => {
-    const records = props.records;
 
     // Retrieve config from advanced settings
     const nodeColorProp = props.settings && props.settings.nodeColorProp ? props.settings.nodeColorProp : "color";
@@ -36,6 +35,11 @@ const NeoMapChart = (props: ChartProps) => {
     // Per pixel, scaling factors for the latitude/longitude mapping function.
     const widthScale = 8.55;
     const heightScale = 6.7;
+
+    var key = data.centerLatitude + "," + data.centerLongitude + "," + props.fullscreen;
+    useEffect(() => {
+        data.centerLatitude + "," + data.centerLongitude + "," + props.fullscreen;
+    }, [props.fullscreen])
 
     useEffect(() => {
         buildVisualizationDictionaryFromRecords(props.records);
@@ -130,7 +134,7 @@ const NeoMapChart = (props: ChartProps) => {
                 extractGraphEntitiesFromField(field);
             })
         });
-       
+
         // Assign proper colors & coordinates to nodes.
         const totalColors = categoricalColorSchemes[nodeColorScheme].length;
         const nodeLabelsList = Object.keys(nodeLabels);
@@ -161,7 +165,7 @@ const NeoMapChart = (props: ChartProps) => {
             return update(node, { pos: node.pos ? node.pos : assignedPos, color: assignedColor ? assignedColor : defaultNodeColor });
 
         });
-     
+
         // Assign proper curvatures to relationships.
         const linksList = Object.values(links).map(nodePair => {
             return nodePair.map((link, i) => {
@@ -299,7 +303,7 @@ const NeoMapChart = (props: ChartProps) => {
     const fullscreen = props.fullscreen ? props.fullscreen : true;
 
     // Draw the component.
-    return <MapContainer /*ref={observe}*/ key={data.centerLatitude + "," + data.centerLongitude + "," + fullscreen} style={{ width: "100%", height: "100%" }}
+    return <MapContainer /*ref={observe}*/ key={key} style={{ width: "100%", height: "100%" }}
         center={[data.centerLatitude ? data.centerLatitude : 0, data.centerLongitude ? data.centerLongitude : 0]}
         zoom={data.zoom ? data.zoom : 0}
         maxZoom={18}

--- a/src/chart/ParameterSelectionChart.tsx
+++ b/src/chart/ParameterSelectionChart.tsx
@@ -83,7 +83,7 @@ const NeoParameterSelectionChart = (props: ChartProps) => {
                 inputValue={inputText}
                 onInputChange={(event, value) => {
                     setInputText("" + value);
-                    debouncedQueryCallback(query, { input: value }, setExtraRecords);
+                    debouncedQueryCallback(query, { input: ""+value }, setExtraRecords);
                 }}
                 getOptionSelected={(option, value) => (option && option.toString()) === (value && value.toString())}
                 value={value ? value.toString() : "" + currentValue}

--- a/src/chart/visualizations/BarVisualization.tsx
+++ b/src/chart/visualizations/BarVisualization.tsx
@@ -69,8 +69,8 @@ export default function BarVisualization(props: ExtendedChartReportProps) {
         keys={keys}
         indexBy="index"
         margin={{ top: marginTop, right: (legend) ? legendWidth + marginRight : marginRight, bottom: marginBottom, left: marginLeft }}
+        valueScale={{ type: valueScale }}
         padding={0.3}
-        // valueScale={{ type: valueScale }}
         minValue={minValue}
         maxValue={maxValue}
         colors={{ scheme: colorScheme }}

--- a/src/config/ReportConfig.tsx
+++ b/src/config/ReportConfig.tsx
@@ -330,108 +330,6 @@ export const REPORT_TYPES = {
         useRecordMapper: true,
         maxRecords: 100,
         settings: {
-            "sortByValue": {
-                label: "Auto-sort slices by value",
-                type: SELECTION_TYPES.LIST,
-                values: [true, false],
-                default: false
-            },
-            "enableArcLabels": {
-                label: "Show Values in slices",
-                type: SELECTION_TYPES.LIST,
-                values: [true, false],
-                default: true
-            },
-            "enableArcLinkLabels": {
-                label: "Show categories next to slices",
-                type: SELECTION_TYPES.LIST,
-                values: [true, false],
-                default: true
-            },
-            "legend": {
-                label: "Show legend under visualization",
-                type: SELECTION_TYPES.LIST,
-                values: [true, false],
-                default: false
-            },
-            "interactive": {
-                label: "Enable interactivity",
-                type: SELECTION_TYPES.LIST,
-                values: [true, false],
-                default: true
-            },
-            "colors": {
-                label: "Color Scheme",
-                type: SELECTION_TYPES.LIST,
-                values: ["nivo", "category10", "accent", "dark2", "paired", "pastel1", "pastel2", "set1", "set2", "set3"],
-                default: "set2"
-            },
-            "innerRadius": {
-                label: "Pie Inner Radius (between 0 and 1)",
-                type: SELECTION_TYPES.NUMBER,
-                default: 0
-            },
-            "padAngle": {
-                label: "Slice padding angle (degrees)",
-                type: SELECTION_TYPES.NUMBER,
-                default: 0
-            },
-            "borderWidth": {
-                label: "Slice border width (px)",
-                type: SELECTION_TYPES.NUMBER,
-                default: 0
-            },
-            "marginLeft": {
-                label: "Margin Left (px)",
-                type: SELECTION_TYPES.NUMBER,
-                default: 24
-            },
-            "marginRight": {
-                label: "Margin Right (px)", 
-                type: SELECTION_TYPES.NUMBER,
-                default: 24
-            },
-            "marginTop": {
-                label: "Margin Top (px)",
-                type: SELECTION_TYPES.NUMBER,
-                default: 24
-            },
-            "marginBottom": {
-                label: "Margin Bottom (px)",
-                type: SELECTION_TYPES.NUMBER,
-                default: 40
-            },
-            "autorun": {
-                label: "Auto-run query",
-                type: SELECTION_TYPES.LIST,
-                values: [true, false],
-                default: true
-            }
-        }
-    },
-    "pie": {
-        label: "Pie Chart",
-        component: NeoPieChart,
-        helperText: <div>A pie chart expects two fields: a <code>category</code> and a <code>value</code>.</div>,
-        selection: {
-            "index": {
-                label: "Category",
-                type: SELECTION_TYPES.TEXT
-            },
-            "value": {
-                label: "Value",
-                type: SELECTION_TYPES.NUMBER,
-                key: true
-            },
-            "key": {
-                label: "Group",
-                type: SELECTION_TYPES.TEXT,
-                optional: true
-            }
-        },
-        useRecordMapper: true,
-        maxRecords: 100,
-        settings: {
             "legend": {
                 label: "Show Legend",
                 type: SELECTION_TYPES.LIST,
@@ -502,6 +400,12 @@ export const REPORT_TYPES = {
                 label: "Margin Bottom (px)",
                 type: SELECTION_TYPES.NUMBER,
                 default: 40
+            },
+            "autorun": {
+                label: "Auto-run query",
+                type: SELECTION_TYPES.LIST,
+                values: [true, false],
+                default: true
             }
         }
     },

--- a/src/dashboard/DashboardDrawer.tsx
+++ b/src/dashboard/DashboardDrawer.tsx
@@ -46,7 +46,7 @@ export const NeoDrawer = ({ open, hidden, connection, dashboardSettings, updateD
                     width: "56px"
                 }
             }
-            open={open}
+            open={open == true} 
         >
             <div style={{
                 display: 'flex',

--- a/src/modal/AboutModal.tsx
+++ b/src/modal/AboutModal.tsx
@@ -13,7 +13,7 @@ import BugReportIcon from '@material-ui/icons/BugReport';
 export const NeoAboutModal = ({ open, handleClose, getDebugState }) => {
     const app = "NeoDash - Neo4j Dashboard Builder";
     const email = "niels.dejong@neo4j.com";
-    const version = "2.0.10";
+    const version = "2.0.11";
 
     const downloadDebugFile = () => {
         const element = document.createElement("a");
@@ -28,7 +28,7 @@ export const NeoAboutModal = ({ open, handleClose, getDebugState }) => {
 
     return (
         <div>
-            <Dialog maxWidth={"lg"} open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+            <Dialog maxWidth={"lg"} open={open == true} onClose={handleClose} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">
                     About NeoDash
                     <IconButton onClick={handleClose} style={{ padding: "3px", float: "right" }}>

--- a/src/modal/ConnectionModal.tsx
+++ b/src/modal/ConnectionModal.tsx
@@ -45,7 +45,7 @@ export default function NeoConnectionModal({ open, standalone, standaloneSetting
     return (
         <div>
            
-            <Dialog maxWidth="xs" open={open} onClose={() => { dismissable ? onConnectionModalClose() : null }} aria-labelledby="form-dialog-title">
+            <Dialog maxWidth="xs" open={open == true} onClose={() => { dismissable ? onConnectionModalClose() : null }} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">{standalone ? "Connect to Dashboard" : "Connect to Neo4j"}
                     <IconButton style={{ padding: "3px", float: "right" }}>
                         <Badge badgeContent={""} >

--- a/src/modal/DeletePageModal.tsx
+++ b/src/modal/DeletePageModal.tsx
@@ -17,7 +17,7 @@ import { Tooltip } from '@material-ui/core';
 export const NeoDeletePageModal = ({modalOpen, onRemove, handleClose}) => {
 
     return (
-        <Dialog maxWidth={"lg"} open={modalOpen} onClose={handleClose} aria-labelledby="form-dialog-title">
+        <Dialog maxWidth={"lg"} open={modalOpen == true} onClose={handleClose} aria-labelledby="form-dialog-title">
             <DialogTitle id="form-dialog-title">
                 Delete page?
             </DialogTitle>

--- a/src/modal/DocumentationModal.tsx
+++ b/src/modal/DocumentationModal.tsx
@@ -35,7 +35,7 @@ export const NeoDocumentationModal = ({ database }) => {
                 <ListItemText primary="Documentation" />
             </ListItem>
 
-            {open ? <Dialog maxWidth={"xl"} open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+            {open ? <Dialog maxWidth={"xl"} open={open == true} onClose={handleClose} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">
                     Documentation - Example Usage
                     <IconButton onClick={handleClose} style={{ padding: "3px", float: "right" }}>

--- a/src/modal/GraphItemInspectModal.tsx
+++ b/src/modal/GraphItemInspectModal.tsx
@@ -22,7 +22,7 @@ const formatProperty = (property) => {
 export const NeoGraphItemInspectModal = ({ open, handleClose, title, object, textAlign = "left" }) => {
     return (
         <div>
-            <Dialog maxWidth={"lg"} open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+            <Dialog maxWidth={"lg"} open={open == true} onClose={handleClose} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">
                     {title}
                     <IconButton onClick={handleClose} style={{ padding: "3px", marginLeft: "20px", float: "right" }}>

--- a/src/modal/LoadModal.tsx
+++ b/src/modal/LoadModal.tsx
@@ -90,7 +90,7 @@ export const NeoLoadModal = ({ loadDashboard, loadDatabaseListFromNeo4j, loadDas
                 <ListItemText primary="Load" />
             </ListItem>
 
-            <Dialog maxWidth={"lg"} open={loadModalOpen} onClose={handleClose} aria-labelledby="form-dialog-title">
+            <Dialog maxWidth={"lg"} open={loadModalOpen == true} onClose={handleClose} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">
                     <SystemUpdateAltIcon style={{
                         height: "30px",
@@ -163,7 +163,7 @@ export const NeoLoadModal = ({ loadDashboard, loadDatabaseListFromNeo4j, loadDas
                 {/* <DialogActions> */}
                 {/* </DialogActions> */}
             </Dialog>
-            <Dialog maxWidth={"lg"} open={loadFromNeo4jModalOpen} onClose={(e) => { setLoadFromNeo4jModalOpen(false) }} aria-labelledby="form-dialog-title">
+            <Dialog maxWidth={"lg"} open={loadFromNeo4jModalOpen == true} onClose={(e) => { setLoadFromNeo4jModalOpen(false) }} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">
                     Select From Neo4j
                     <IconButton onClick={(e) => { setLoadFromNeo4jModalOpen(false) }} style={{ padding: "3px", float: "right" }}>

--- a/src/modal/NotificationModal.tsx
+++ b/src/modal/NotificationModal.tsx
@@ -21,7 +21,7 @@ export const NeoNotificationModal = ({ open, title, text, dismissable,
 
     return (
         <div>
-            <Dialog maxWidth={"lg"} open={open} onClose={(e) => {
+            <Dialog maxWidth={"lg"} open={open == true} onClose={(e) => {
                 if(dismissable){
                     onNotificationClose();
                     if (openConnectionModalOnClose) {

--- a/src/modal/SaveModal.tsx
+++ b/src/modal/SaveModal.tsx
@@ -103,7 +103,7 @@ export const NeoSaveModal = ({ dashboard, connection, saveDashboardToNeo4j, load
                 <ListItemText primary="Save" />
             </ListItem>
 
-            <Dialog maxWidth={"lg"} open={saveModalOpen} onClose={handleClose} aria-labelledby="form-dialog-title">
+            <Dialog maxWidth={"lg"} open={saveModalOpen == true} onClose={handleClose} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">
                     <SaveIcon style={{
                         height: "30px",
@@ -154,7 +154,7 @@ export const NeoSaveModal = ({ dashboard, connection, saveDashboardToNeo4j, load
                 </DialogActions>
             </Dialog>
 
-            <Dialog maxWidth={"lg"} open={saveToNeo4jModalOpen} onClose={(e) => { setSaveToNeo4jModalOpen(false) }} aria-labelledby="form-dialog-title">
+            <Dialog maxWidth={"lg"} open={saveToNeo4jModalOpen == true} onClose={(e) => { setSaveToNeo4jModalOpen(false) }} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">
 
                     Save to Neo4j

--- a/src/modal/ShareModal.tsx
+++ b/src/modal/ShareModal.tsx
@@ -88,7 +88,7 @@ export const NeoShareModal = ({ connection, loadDashboardListFromNeo4j, loadData
                 <ListItemText primary="Share" />
             </ListItem>
 
-            <Dialog maxWidth={"lg"} open={shareModalOpen} onClose={handleClose} aria-labelledby="form-dialog-title">
+            <Dialog key={1} maxWidth={"lg"} open={shareModalOpen == true} onClose={handleClose} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">
                     <ShareIcon style={{
                         height: "30px",
@@ -200,7 +200,7 @@ export const NeoShareModal = ({ connection, loadDashboardListFromNeo4j, loadData
                     </DialogContentText> : <></>}
                 </DialogContent>
             </Dialog>
-            <Dialog maxWidth={"lg"} open={loadFromNeo4jModalOpen} onClose={(e) => { setLoadFromNeo4jModalOpen(false) }} aria-labelledby="form-dialog-title">
+            <Dialog key={2} maxWidth={"lg"} open={loadFromNeo4jModalOpen == true} onClose={(e) => { setLoadFromNeo4jModalOpen(false) }} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">
                     Select From Neo4j
                     <IconButton onClick={(e) => { setLoadFromNeo4jModalOpen(false) }} style={{ padding: "3px", float: "right" }}>
@@ -246,7 +246,7 @@ export const NeoShareModal = ({ connection, loadDashboardListFromNeo4j, loadData
 
                 </DialogContent>
             </Dialog>
-            <Dialog maxWidth={"lg"} open={loadFromFileModalOpen} onClose={(e) => { setLoadFromFileModalOpen(false) }} aria-labelledby="form-dialog-title">
+            <Dialog key={3} maxWidth={"lg"} open={loadFromFileModalOpen == true} onClose={(e) => { setLoadFromFileModalOpen(false) }} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">
                     Select from URL
                     <IconButton onClick={(e) => { setLoadFromFileModalOpen(false) }} style={{ padding: "3px", float: "right" }}>

--- a/src/modal/UpgradeOldDashboardModal.tsx
+++ b/src/modal/UpgradeOldDashboardModal.tsx
@@ -11,7 +11,7 @@ import { TextareaAutosize } from '@material-ui/core';
 export const NeoUpgradeOldDashboardModal = ({ open, text, clearOldDashboard, loadDashboard }) => {
     return (
         <div>
-            <Dialog maxWidth={"lg"} open={open} aria-labelledby="form-dialog-title">
+            <Dialog maxWidth={"lg"} open={open == true} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">
                     Old Dashboard Found
                 </DialogTitle>

--- a/src/modal/WelcomeScreenModal.tsx
+++ b/src/modal/WelcomeScreenModal.tsx
@@ -32,7 +32,7 @@ export const NeoWelcomeScreenModal = ({ welcomeScreenOpen, setWelcomeScreenOpen,
 
     return (
         <div>
-            <Dialog maxWidth="xs" open={welcomeScreenOpen} aria-labelledby="form-dialog-title">
+            <Dialog maxWidth="xs" open={welcomeScreenOpen == true} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">NeoDash - Neo4j Dashboard Builder
                     <IconButton disabled style={{ color: "white", padding: "5px", float: "right" }}>
                         ⚡
@@ -131,7 +131,7 @@ export const NeoWelcomeScreenModal = ({ welcomeScreenOpen, setWelcomeScreenOpen,
             </Dialog>
 
             {/* Prompt when creating new dashboard with existing cache */}
-            <Dialog maxWidth="xs" open={promptOpen} aria-labelledby="form-dialog-title">
+            <Dialog maxWidth="xs" open={promptOpen == true} aria-labelledby="form-dialog-title">
                 <DialogTitle id="form-dialog-title">Create new dashboard
                     <IconButton disabled style={{ color: "white", padding: "5px", float: "right" }}>
                         ⚠️

--- a/src/report/RecordProcessing.tsx
+++ b/src/report/RecordProcessing.tsx
@@ -350,6 +350,10 @@ function RenderString(value) {
 }
 
 function RenderInteger(value) {
+    // if we cannot cast to integer, use the generic number renderer.
+    if(!value.toInt){
+        return RenderNumber(value);
+    }
     const integer = value.toInt().toLocaleString();
     return integer;
 }
@@ -393,6 +397,7 @@ export const rendererForType: any = {
         type: 'string',
         // valueGetter enables sorting and filtering on string values inside the object
         valueGetter: (c) => { return JSON.stringify(c.value) },
+        renderValue: (c) => { return JSON.stringify(c.value) }
     },
     "array": {
         type: 'string',
@@ -425,5 +430,10 @@ export function getRendererForValue(value) {
 
 export function renderValueByType(value){
     const renderer = getRendererForValue(value);
-    return renderer.renderValue({value:value});
+    if(renderer){
+        return renderer.renderValue({value:value});
+    }else{
+        return value.toString();
+    }
+   
 }

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -12,7 +12,6 @@ FROM nginx:alpine AS neodash
 RUN apk upgrade
 COPY --from=build-stage /usr/local/src/neodash/dist /usr/share/nginx/html
 
-
 # Set default config options
 ENV standalone=false
 


### PR DESCRIPTION
Stability fixes to supplement 2.0.7:
- Fix for rendering dictionaries in tables/single value charts.
- Added resize handler for fullscreen map views.
- Added missing auto-run config to pie charts.
- Fixed broken value scale parameter for bar charts.
